### PR TITLE
Allow customizing the base path and don't mount the BPF fs if it is already mounted

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -3,6 +3,7 @@ package beyla
 import (
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/caarlos0/env/v9"
@@ -36,6 +37,7 @@ var DefaultConfig = Config{
 		BatchLength:  100,
 		BatchTimeout: time.Second,
 		BpfBaseDir:   "/var/run/beyla",
+		BpfPath:      fmt.Sprintf("beyla-%d", os.Getpid()),
 	},
 	Grafana: otel.GrafanaConfig{
 		OTLP: otel.GrafanaOTLP{

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -93,6 +93,7 @@ network:
 			BatchLength:  100,
 			BatchTimeout: time.Second,
 			BpfBaseDir:   "/var/run/beyla",
+			BpfPath:      DefaultConfig.EBPF.BpfPath,
 		},
 		Grafana: otel.GrafanaConfig{
 			OTLP: otel.GrafanaOTLP{

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -2,9 +2,7 @@ package discover
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"os"
 	"path"
 
 	"github.com/cilium/ebpf/link"
@@ -193,7 +191,7 @@ func monitorPIDs(tracer *ebpf.ProcessTracer, ie *Instrumentable) {
 // it will be:
 //   - current beyla PID
 func BuildPinPath(cfg *beyla.Config) string {
-	return path.Join(cfg.EBPF.BpfBaseDir, fmt.Sprintf("beyla-%d", os.Getpid()))
+	return path.Join(cfg.EBPF.BpfBaseDir, cfg.EBPF.BpfPath)
 }
 
 func (ta *TraceAttacher) notifyProcessDeletion(ie *Instrumentable) {

--- a/pkg/internal/ebpf/common/common.go
+++ b/pkg/internal/ebpf/common/common.go
@@ -55,6 +55,10 @@ type TracerConfig struct {
 	// By default, it will be /var/run/beyla
 	BpfBaseDir string `yaml:"bpf_fs_base_dir" env:"BEYLA_BPF_FS_BASE_DIR"`
 
+	// BpfPath specifies the path in the base directory where the BPF pinned maps will be mounted.
+	// By default, it will be beyla-<pid>.
+	BpfPath string `yaml:"bpf_fs_path" env:"BEYLA_BPF_FS_PATH"`
+
 	// If enabled, the kprobes based HTTP request tracking will start tracking the request
 	// headers to process any 'Traceparent' fields.
 	TrackRequestHeaders bool `yaml:"track_request_headers" env:"BEYLA_BPF_TRACK_REQUEST_HEADERS"`


### PR DESCRIPTION
This allows running the main beyla container without being privileged, or having the SYS_ADMIN capability.  Here are the k8s manifests I used (you need to change the container image to one built from this PR):

```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: beyla-agent
  labels:
    app: beyla
spec:
  selector:
    matchLabels:
      app: beyla
  template:
    metadata:
      labels:
        app: beyla
      annotations:
        # allow beyla to write to /sys/fs/bpf by setting the
        # apparmor policy to unconfined.
        container.apparmor.security.beta.kubernetes.io/beyla: "unconfined"
    spec:
      serviceAccountName: beyla
      hostPID: true
      # IMPORTANT: add an init container to mount the BPF filesystem
      initContainers:
        - name: mount-bpf-fs
          image: grafana/beyla:1.4.1
          args:
          # Create the directory using the Pod UID, and mount the BPF filesystem.
          - 'mkdir -p /sys/fs/bpf/$BEYLA_BPF_FS_PATH && mount -t bpf bpf /sys/fs/bpf/$BEYLA_BPF_FS_PATH'
          command:
          - /bin/bash
          - -c
          - --
          securityContext:
            # IMPORTANT: The init container is privileged so that it can use bidirectional mount propagation
            privileged: true
          volumeMounts:
          - name: bpffs
            mountPath: /sys/fs/bpf
            # IMPORTANT: Make sure the mount is propagated back to the host so it can be used by the Beyla container
            mountPropagation: Bidirectional
          env:
            - name: BEYLA_BPF_FS_PATH
              valueFrom:
                fieldRef:
                  fieldPath: metadata.uid
      containers:
        - name: beyla
          image: <image built from this PR>
          securityContext:
            seccompProfile:
              type: RuntimeDefault
            runAsUser: 0
            readOnlyRootFilesystem: true
            capabilities:
              add:
                - BPF
                - SYS_PTRACE
                - NET_RAW
                - CHECKPOINT_RESTORE
                - DAC_READ_SEARCH
                - PERFMON
              drop:
                - ALL
          env:
            - name: BEYLA_CONFIG_PATH
              value: "/config/beyla-config.yml"
            - name: BEYLA_BPF_FS_PATH
              valueFrom:
                fieldRef:
                  fieldPath: metadata.uid
          volumeMounts:
          - name: bpffs
            mountPath: /sys/fs/bpf
            # IMPORTANT: use HostToContainer to propagate the mount from the init container to the Beyla container
            mountPropagation: HostToContainer
          - name: beyla-config
            mountPath: /config
      volumes:
      - name: bpffs
        hostPath:
          path: /sys/fs/bpf
      - name: beyla-config
        configMap:
          name: beyla-config
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: beyla-config
data:
  beyla-config.yml: |
    discovery:
      services:
      # only gather metrics from workloads running as a pod
      - k8s_pod_name: .+
    otel_metrics_export:
      endpoint: http://otel-collector:4317
      interval: 30s
    attributes:
      kubernetes:
        enable: true
    ebpf:
      bpf_fs_base_dir: /sys/fs/bpf
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: beyla
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: beyla
rules:
  - apiGroups: ["apps"]
    resources: ["replicasets"]
    verbs: ["list", "watch"]
  - apiGroups: [""]
    resources: ["pods"]
    verbs: ["list", "watch"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: beyla
subjects:
  - kind: ServiceAccount
    name: beyla
    namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: beyla
```